### PR TITLE
Improve ErrorBoundary component to better display errors & fixed "SAFE_MODE_NOTICE_THEMES" key I think

### DIFF
--- a/src/core/i18n/default.json
+++ b/src/core/i18n/default.json
@@ -74,7 +74,7 @@
     "RETRY_RENDER": "Retry Render",
     "SAFE_MODE": "Safe Mode",
     "SAFE_MODE_NOTICE_PLUGINS": "You are in Safe Mode, so plugins cannot be loaded. Disable any misbehaving plugins, then return to Normal Mode from the General settings page.",
-    "SAFE_MODE_NOTICE_THEMES": "You are in Safe Mode, meaning themes have been temporarily disabled. {enabled, select, true { If a theme appears to be causing the issue, you can press below to disable it persistently.} false { }}",
+    "SAFE_MODE_NOTICE_THEMES": "You are in Safe Mode, meaning themes have been temporarily disabled. {enabled, select, true {If a theme appears to be causing the issue, you can press below to disable it persistently.} false {}}",
     "SEARCH": "Search",
     "STACK_TRACE": "Stack Trace",
     "SUCCESSFULLY_INSTALLED": "Successfully installed",

--- a/src/core/i18n/default.json
+++ b/src/core/i18n/default.json
@@ -74,7 +74,7 @@
     "RETRY_RENDER": "Retry Render",
     "SAFE_MODE": "Safe Mode",
     "SAFE_MODE_NOTICE_PLUGINS": "You are in Safe Mode, so plugins cannot be loaded. Disable any misbehaving plugins, then return to Normal Mode from the General settings page.",
-    "SAFE_MODE_NOTICE_THEMES": "You are in Safe Mode, meaning themes have been temporarily disabled.{enabled, select, true { If a theme appears to be causing the issue, you can press below to disable it persistently.}}",
+    "SAFE_MODE_NOTICE_THEMES": "You are in Safe Mode, meaning themes have been temporarily disabled. {enabled, select, true { If a theme appears to be causing the issue, you can press below to disable it persistently.} false { }}",
     "SEARCH": "Search",
     "STACK_TRACE": "Stack Trace",
     "SUCCESSFULLY_INSTALLED": "Successfully installed",

--- a/src/lib/ui/components/ErrorBoundary.tsx
+++ b/src/lib/ui/components/ErrorBoundary.tsx
@@ -6,10 +6,12 @@ import { FormText } from "@ui/components/discord/Forms";
 import { createThemedStyleSheet } from "@ui/styles";
 import { ScrollView } from "react-native";
 
-interface ErrorBoundaryState {
-    hasErr: boolean;
-    errText?: string;
-}
+type ErrorBoundaryState = {
+    hasErr: false;
+} | {
+    hasErr: true;
+    error: Error;
+};
 
 export interface ErrorBoundaryProps {
     children: JSX.Element | JSX.Element[];
@@ -34,7 +36,7 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
         this.state = { hasErr: false };
     }
 
-    static getDerivedStateFromError = (error: Error) => ({ hasErr: true, errText: error.message });
+    static getDerivedStateFromError = (error: Error) => ({ hasErr: true, error });
 
     render() {
         if (!this.state.hasErr) return this.props.children;
@@ -42,12 +44,16 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
         return (
             <ScrollView style={styles.view}>
                 <FormText style={styles.title}>{Strings.UH_OH}</FormText>
-                <Codeblock selectable style={{ marginBottom: 5 }}>{this.state.errText}</Codeblock>
+                <Codeblock selectable style={{ marginBottom: 5 }}>{this.state.error.name}</Codeblock>
+                <Codeblock selectable style={{ marginBottom: 5 }}>{this.state.error.message}</Codeblock>
+                {this.state.error.stack && <ScrollView style={{ maxHeight: 420, marginBottom: 5 }}>
+                    <Codeblock selectable>{this.state.error.stack}</Codeblock>
+                </ScrollView>}
                 <Button
                     color={Button.Colors.RED}
                     size={Button.Sizes.MEDIUM}
                     look={Button.Looks.FILLED}
-                    onPress={() => this.setState({ hasErr: false, errText: undefined })}
+                    onPress={() => this.setState({ hasErr: false })}
                     text={Strings.RETRY}
                 />
             </ScrollView>


### PR DESCRIPTION
I fixed the `SAFE_MODE_NOTICE_THEMES` translation key I think by adding `false { }`

closes #8

From this:

![image](https://github.com/pyoncord/Bunny/assets/38010540/381a444f-af7e-432c-ab6e-25c9dd85bc93)

To this:

![image](https://github.com/pyoncord/Bunny/assets/38010540/44cfc998-d7f9-4cd0-99ce-05baa1436f76)

this change was enough to for me figure out the location of the problem described in #8 