### PR TITLE
feat(plugins): add initial boolean to plugin api

### DIFF
--- a/src/lib/plugins/api.ts
+++ b/src/lib/plugins/api.ts
@@ -15,7 +15,7 @@ function shimDisposableFn<F extends DisposableFn>(unpatches: (() => void)[], f: 
     }) as F;
 }
 
-export function createBunnyPluginAPI(id: string) {
+export function createBunnyPluginAPI(id: string, initial = false) {
     const disposers = new Array<DisposableFn>;
 
     // proxying this would be a good idea
@@ -41,7 +41,8 @@ export function createBunnyPluginAPI(id: string) {
         plugin: {
             createStorage: () => createStorage(`plugins/storage/${id}.json`),
             manifest: registeredPlugins.get(id),
-            logger
+            logger,
+            initial
         }
     } as unknown as BunnyPluginObject;
 

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -270,7 +270,7 @@ export async function uninstallPlugin(id: string) {
  * Starts a registered, installed, enabled and unstarted plugin. Otherwise, would throw.
  * @param id The enabled plugin ID
  */
-export async function startPlugin(id: string) {
+export async function startPlugin(id: string, initial = false) {
     const manifest = registeredPlugins.get(id);
 
     // horror
@@ -298,7 +298,7 @@ export async function startPlugin(id: string) {
 
         // Stage two, load the plugin
         try {
-            const api = createBunnyPluginAPI(id);
+            const api = createBunnyPluginAPI(id, initial);
             pluginInstance = instantiator(api.object, p => {
                 return Object.assign(p, {
                     manifest
@@ -375,7 +375,7 @@ export async function initPlugins() {
     // Now, start all enabled plugins...
     await Promise.allSettled([...registeredPlugins.keys()].map(async id => {
         if (isPluginEnabled(id)) {
-            await startPlugin(id);
+            await startPlugin(id, true);
         }
     }));
 }

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -47,6 +47,7 @@ export interface PluginInstanceInternal extends PluginInstance {
 export interface BunnyPluginProperty {
     readonly manifest: BunnyPluginManifestInternal;
     readonly logger: Logger;
+    readonly initial: boolean;
     createStorage<T>(): ReturnType<typeof createStorage<T>>;
 }
 


### PR DESCRIPTION
Adds a boolean called `initial` to the plugin api object that's
- `true` if the plugin was loaded on startup
- `false` if it was enabled/installed by the user afterwards