### PR TITLE
fix(lib/api/native/modules): add more native module fallbacks

### DIFF
--- a/src/lib/api/native/modules/index.ts
+++ b/src/lib/api/native/modules/index.ts
@@ -3,9 +3,8 @@ import { RNModules } from "./types";
 const nmp = window.nativeModuleProxy;
 
 export const MMKVManager = nmp.MMKVManager as RNModules.MMKVManager;
-export const FileManager = (nmp.DCDFileManager ?? nmp.RTNFileManager) as RNModules.FileManager;
-export const ClientInfoManager = nmp.InfoDictionaryManager ?? nmp.RTNClientInfoManager;
-export const DeviceManager = nmp.DCDDeviceManager ?? nmp.RTNDeviceManager;
+export const FileManager = (nmp.NativeFileModule ?? nmp.RTNFileManager ?? nmp.DCDFileManager) as RNModules.FileManager;
+export const ClientInfoManager = nmp.NativeClientInfoModule ?? nmp.RTNClientInfoManager ?? nmp.InfoDictionaryManager;
+export const DeviceManager = nmp.NativeDeviceModule ?? nmp.RTNDeviceManager ?? nmp.DCDDeviceManager;
 export const { BundleUpdaterManager } = nmp;
-export const ThemeManager = nmp.RTNThemeManager ?? nmp.DCDTheme;
-
+export const ThemeManager = nmp.NativeThemeModule ?? nmp.RTNThemeManager ?? nmp.DCDTheme;


### PR DESCRIPTION
Fixes support for Discord 254.19+

closes #99 